### PR TITLE
Add VidiU Go compatibility

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -6,6 +6,10 @@ This module will allow you to control a Teradek VidiU device.
 * Enter the IP address of the device in the configuration settings.
 * Enter the password of the device as configured in the web interface of the VidiU.
 * The device will use HTTP port 80.
+* Set VidiU Go dropdown to Yes for compatability (Experimental)
+    * Turns off collection of variables not supported by VidiU Go
+    * Adds check for VidiU Go stop responding to status requests
+    * Adds check for VidiU Go powered up after Companion running
 
 **Available actions:**
 * Start Broadcasting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "teradek-vidiu",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Stream"


### PR DESCRIPTION
Added configuration choice for reduced capability if using VidiU Go.
For Go, use setTimeout instead of setInterval (saves the Companion log when errors.)
Added interval check to see if the device is now on the network.